### PR TITLE
Allow custom highlight as function

### DIFF
--- a/lua/material/colors/init.lua
+++ b/lua/material/colors/init.lua
@@ -193,7 +193,6 @@ colors.syntax.keyword  = colors.main.purple
 colors.syntax.value    = colors.main.orange
 colors.syntax.operator = colors.main.cyan
 colors.syntax.fn       = colors.main.blue
-colors.syntax.parameter = colors.main.darkorange
 colors.syntax.string   = colors.main.green
 colors.syntax.type     = colors.main.purple
 

--- a/lua/material/highlights/init.lua
+++ b/lua/material/highlights/init.lua
@@ -26,7 +26,6 @@ M.async_highlights = {}
 M.main_highlights.syntax = function()
     local syntax_hls = {
         Identifier     = { fg = s.variable },
-        Parameter      = { fg = s.parameter },
         Comment        = { fg = s.comments },
         Keyword        = { fg = s.keyword },
         Conditional    = { fg = s.keyword },
@@ -68,7 +67,6 @@ M.main_highlights.syntax = function()
     syntax_hls.Conditional  = vim.tbl_extend("keep", syntax_hls.Conditional, styles.keywords)
     syntax_hls.Function     = vim.tbl_extend("keep", syntax_hls.Function, styles.functions)
     syntax_hls.Identifier   = vim.tbl_extend("keep", syntax_hls.Identifier, styles.variables)
-    syntax_hls.Parameter    = vim.tbl_extend("keep", syntax_hls.Parameter, styles.parameters)
     syntax_hls.Keyword      = vim.tbl_extend("keep", syntax_hls.Keyword, styles.keywords)
     syntax_hls.Repeat       = vim.tbl_extend("keep", syntax_hls.Repeat, styles.keywords)
     syntax_hls.String       = vim.tbl_extend("keep", syntax_hls.String, styles.strings)
@@ -102,7 +100,7 @@ M.main_highlights.treesitter = function()
             ["@variable.builtin"]   = { link = "@keyword" },
             -- ["@field"]              = { fg = e.fg_dark },
             ["@property"]           = { fg = e.fg_dark },
-            ["@variable.parameter"] = { fg = s.parameter },
+            ["@variable.parameter"] = { link = "Identifier" },
             ["@variable.member"]    = { fg = e.fg_dark }, -- Fields
             ["@string.special.symbol"] = { fg = m.yellow },
 

--- a/lua/material/util/config.lua
+++ b/lua/material/util/config.lua
@@ -16,7 +16,6 @@ local defaults = {
         strings = {},
         keywords = {},
         functions = {},
-        parameters = {},
         variables = {},
         operators = {},
         types = {},

--- a/lua/material/util/init.lua
+++ b/lua/material/util/init.lua
@@ -113,6 +113,8 @@ local load_async = function()
     -- load user defined higlights
     if type(settings.custom_highlights) == "table" then
         apply_highlights(settings.custom_highlights)
+    elseif type(settings.custom_highlights) == "function" then
+        apply_highlights(settings.custom_highlights(colors))
     end
 
     -- if this function gets called asyncronously, this closure is needed


### PR DESCRIPTION
Removes changes added before with parameter highlighting and instead allows a user to use a function to supply custom highlights.

Moar flexible == gud